### PR TITLE
SafeMath for uint256

### DIFF
--- a/contracts/BondingNOM.sol
+++ b/contracts/BondingNOM.sol
@@ -17,19 +17,17 @@ interface ERC20Token {
 /// @title wNOM Bonding Contract
 /// @author Charles Dusek
 contract BondingNOM is Ownable {
-    ERC20Token nc; // NOM contract (nc)
-
-    // Address of the nc (NOM ERC20 Contract)
+    ERC20Token nc;
+    using SafeMath for uint256;
+    /// @notice Address of the nc (NOM ERC20 Contract)
     address public NOMTokenContract;
     uint256 public supplyNOM = 0;
     uint256 public priceBondCurve = 0;
     uint128 private constant MAX_64x64 = 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
     uint8 public decimals = 18;
-    // Bonding Curve parameter
     uint256 public a = SafeMath.mul(100000000, 10**decimals);
 
     event Transaction(address indexed _by, uint256 amountNOM, uint256 amountETH, uint256 price, uint256 supply, string buyOrSell, int128 slippage);
-   
 
     constructor (address NOMContAddr) {
         // Add in the NOM ERC20 contract address
@@ -37,45 +35,54 @@ contract BondingNOM is Ownable {
         nc = ERC20Token(NOMContAddr);
     }
 
+    /// @notice Return the NOM Token Contract address
     function getNOMAddr() public view returns (address) {
         return NOMTokenContract;
     }
 
+    /// @return Return the NOM Token circulate supply
     function getSupplyNOM() public view returns (uint256) {
         return supplyNOM;
     }
 
+    /// @return Return the price based on current NOM supply
     function getBondPrice() public view returns (uint256) {
         return priceBondCurve;
     }
 
-    // Conversion from token at 18 decimals to 64x64
+    /// @param token uint256 token amount
+    /// @return Return token amount to F64(Fixed Point 64) format
+    /// @notice This function will use `ABDKMath64x64.divu` module from `abdk-libraries-solidity` library
     function tokToF64(uint256 token) public view returns(int128) {
         return ABDKMath64x64.divu(token, 10**uint256(decimals));
     }
 
-    // Convert Fixed Point 64 to Token UInt256
+    /// @return Return F64(Fixed Point 64) token amount to uint256
+    /// @notice This function will use `ABDKMath64x64.mulu` module from `abdk-libraries-solidity` library
     function f64ToTok(int128 fixed64) public view returns(uint256) {
         return ABDKMath64x64.mulu(fixed64, 10**uint256(decimals));
     }
 
-    // ETH/NOM = (#NOM Sold/(a))^2
+    /// @return Return the token price base on the input supply amount
+    /// @param _supplyNOM token supply amount in uint256
+    /// @notice Formula: `ETH/NOM = pow(_supplyNOM/a, 2)`  Using this function, everyone can predict the exact price base on token supply
     function priceAtSupply(uint256 _supplyNOM) public view returns(uint256) {
         return  f64ToTok(
             ABDKMath64x64.pow(
                 ABDKMath64x64.div(
-                    tokToF64(_supplyNOM), 
+                    tokToF64(_supplyNOM),
                     tokToF64(a)
                 ),
                 uint256(2)
             )
-        );  
+        );
     }
 
-    // #NOM Sold = sqrt(ETH/NOM) * a
-    // Input 64.64 fixed point number
+    /// @return Return token supply amount for input price
+    /// @param price F64(Fixed Point 64) formated amount
+    /// @notice Formula: `_suppliedNom = sqrt(ETH/NOM) * a`  Using this function, everyone can predict the exact token supply base on token price
     function supplyAtPrice(uint256 price) public view returns (uint256) {
-        return f64ToTok(  
+        return f64ToTok(
             ABDKMath64x64.mul(
                 ABDKMath64x64.sqrt(
                     tokToF64(price)
@@ -85,16 +92,19 @@ contract BondingNOM is Ownable {
         );
     }
 
-    // NOM supply range to ETH
-    // Integrate over curve to get amount of ETH needed to buy amount of NOM
-    // ETH = a/3((supplyNOM_Top/a)^3 - (supplyNOM_Bot/a)^3)
+
+    /// @return Return NOM supply range to ETH
+    /// @param supplyTop NOM supply top amount
+    /// @param supplyBot NOM supply bottom amount
+    /// @notice Formula: `ETH = a/3((supplyNOM_Top/a)^3 - (supplyNOM_Bot/a)^3)`
+    /// Integrate over a curve to get the amount of ETH needed to buy the amount of NOM
     function NOMSupToETH(uint256 supplyTop, uint256 supplyBot) public view returns(uint256) {
         require(supplyTop > supplyBot, "Supply Top is not greater than Supply Bot");
         return f64ToTok(
             ABDKMath64x64.mul(
                 // a/3
                 ABDKMath64x64.div(
-                    tokToF64(a), 
+                    tokToF64(a),
                     ABDKMath64x64.fromUInt(uint256(3))
                 ),
                 // ((NomSold_Top/a)^3 - (supplyNOM_Bot/a)^3)
@@ -102,17 +112,17 @@ contract BondingNOM is Ownable {
                     // (NomSold_Top/a)^3
                     ABDKMath64x64.pow(
                         ABDKMath64x64.div(
-                            tokToF64(supplyTop), 
+                            tokToF64(supplyTop),
                             tokToF64(a)
-                        ), 
+                        ),
                         uint256(3)
                     ),
                     // (NomSold_Bot/a)^3
                     ABDKMath64x64.pow(
                         ABDKMath64x64.div(
-                            tokToF64(supplyBot), 
+                            tokToF64(supplyBot),
                             tokToF64(a)
-                        ), 
+                        ),
                         uint256(3)
                     )
                 )
@@ -120,86 +130,72 @@ contract BondingNOM is Ownable {
         );
     }
 
-    // Returns quote for a particular amount of NOM (Dec 18) in ETH (Dec 18)
-    // 1. Determine supply range based on spread and current curve price based on supplyNOM
-    // 2. Integrate over curve to get amount of ETH needed to buy amount of NOM
-    // ETH = a/3((supplyNOM_Top/a)^3 - (supplyNOM_Bot/a)^3)
-    // Parameters:
-    // Input
-    // uint256 buyAmount: amount of NOM to be purchased in 18 decimal
-    // Output
-    // uint256: amount of ETH needed in Wei or ETH 18 decimal
+
+    /// @return Return quote for a particular amount of NOM (Dec 18) in ETH (Dec 18)
+    /// @param amountNOM amount of NOM to be purchased in 18 decimal
+    /// @notice 1. Determine supply range based on spread and current curve price based on supplyNOM
+    /// 2. Integrate over curve to get amount of ETH needed to buy amount of NOM
+    /// ETH = a/3((supplyNOM_Top/a)^3 - (supplyNOM_Bot/a)^3)
+    /// Parameters:
+    /// Input
+    /// uint256 buyAmount: amount of NOM to be purchased in 18 decimal
+    /// Output
+    /// uint256: amount of ETH needed in Wei or ETH 18 decimal
     function buyQuoteNOM(uint256 amountNOM) public view returns(uint256) {
-        uint256 supplyTop = SafeMath.add(supplyNOM, amountNOM);
+        uint256 supplyTop = supplyNOM.add(amountNOM);
         uint256 amountETH = NOMSupToETH(supplyTop, supplyNOM);
-        return SafeMath.sub(amountETH, SafeMath.div(amountETH, uint256(100)));
+        return amountETH.sub(amountETH.div(100));
     }
 
-    /**
-    * Calculate cubrt (x) rounding down.  Revert if x < 0.
-    *
-    * @param x signed 64.64-bit fixed point number
-    * @return signed 64.64-bit fixed point number
-    */
+    /// @return Return cubrt(x) rounding down, where x is int128 integer
+    /// @param x signed 64.64-bit fixed point number
     function cubrt (int128 x) public pure returns (int128) {
         require (x >= 0);
         return int128 (cubrtu (uint256 (x) << 64));
     }
 
-    /**
-    * Calculate cube root cubrtu (x) rounding down, where x is unsigned 256-bit integer
-    * number.
-    *
-    * @param x unsigned 256-bit integer number
-    * @return unsigned 256-bit integer number
-    */
+
+    /// @return Return cubrtu(x) rounding down, where x is unsigned 256-bit integer
+    /// @param x unsigned 256-bit integer number
     function cubrtu (uint256 x) public pure returns (uint256) {
         if (x == 0) return 0;
         else {
-        uint256 xx = x;
-        uint256 r = 1;
-
-        if (xx >= 0x1000000000000000000000000000000000000) { xx >>= 144; r <<= 48; }
-        if (xx >= 0x1000000000000000000) { xx >>= 72; r <<= 24; }
-        if (xx >= 0x1000000000) { xx >>= 36; r <<= 12; }
-        if (xx >= 0x40000) { xx >>= 18; r <<= 6; }
-        if (xx >= 0x1000) { xx >>= 12; r <<= 4; }
-        if (xx >= 0x200) { xx >>= 9; r <<= 3; }
-        if (xx >= 0x40) { xx >>= 6; r <<= 2; }
-        if (xx >= 0x8) { r <<= 1; }
-        r = (x/(r**2) + 2*r)/3;
-        r = (x/(r**2) + 2*r)/3;
-        r = (x/(r**2) + 2*r)/3;
-        r = (x/(r**2) + 2*r)/3;
-        r = (x/(r**2) + 2*r)/3;
-        r = (x/(r**2) + 2*r)/3;
-        r = (x/(r**2) + 2*r)/3; // Seven iterations should be enough
-        return r;
+            uint256 xx = x;
+            uint256 r = 1;
+            if (xx >= 0x1000000000000000000000000000000000000) { xx >>= 144; r <<= 48; }
+            if (xx >= 0x1000000000000000000) { xx >>= 72; r <<= 24; }
+            if (xx >= 0x1000000000) { xx >>= 36; r <<= 12; }
+            if (xx >= 0x40000) { xx >>= 18; r <<= 6; }
+            if (xx >= 0x1000) { xx >>= 12; r <<= 4; }
+            if (xx >= 0x200) { xx >>= 9; r <<= 3; }
+            if (xx >= 0x40) { xx >>= 6; r <<= 2; }
+            if (xx >= 0x8) { r <<= 1; }
+            r = (x/(r**2) + 2*r)/3;
+            r = (x/(r**2) + 2*r)/3;
+            r = (x/(r**2) + 2*r)/3;
+            r = (x/(r**2) + 2*r)/3;
+            r = (x/(r**2) + 2*r)/3;
+            r = (x/(r**2) + 2*r)/3;
+            r = (x/(r**2) + 2*r)/3; // Seven iterations should be enough
+            return r;
         }
     }
 
-    // Returns Buy Quote for the purchase of NOM based on amount of ETH (Dec 18)
-    // 1. Determine supply bottom
-    // 2. Integrate over curve, and solve for supply top
-    // supplyNOM_Top = a*(3*ETH/a + (supplyNOM_Bot/a)^3)^(1/3)
-    // 3. Subtract supply bottom from top to get #NOM for ETH
-    // Parameters:
-    // Input
-    // uint256 amountETH: amount of ETH in 18 decimal
-    // Output
-    // uint256: amount of NOM in 18 decimal
+    /// @param amountETH amoutt of ETH
+    /// @return Buy Quote for the purchase of NOM based on amount of ETH (Dec 18)
+    /// @notice 1. Determine supply bottom
+    /// 2. Integrate over curve, and solve for supply top supplyNOM_Top = a*(3*ETH/a + (supplyNOM_Bot/a)^3)^(1/3)
+    /// 3. Subtract supply bottom from top to get #NOM for ETH
     function buyQuoteETH(uint256 amountETH) public view returns(uint256) {
-        uint256 amountNet = SafeMath.sub(amountETH, SafeMath.div(amountETH, uint256(100)));
-        
-        
+        uint256 amountNet = amountETH.sub(amountETH.div(100));
         uint256 supplyTop = // supplyNOM_Top = (a^2*(3*ETH + (supplyNOM_Bot/a)^2*supplyNOM_Bot))^(1/3)
             cubrtu(
                 SafeMath.mul(
-                    // a^2               
-                    SafeMath.mul(a, a),    
+                    // a^2
+                    a.mul(a),
                     // (3*ETH + (supplyNOM_Bot/a)^2*supplyNOM_Bot)
                     f64ToTok(
-                        ABDKMath64x64.add(    
+                        ABDKMath64x64.add(
                             ABDKMath64x64.mul(
                                 ABDKMath64x64.fromUInt(uint256(3)),
                                 tokToF64(amountNet)
@@ -217,10 +213,8 @@ contract BondingNOM is Ownable {
                         )
                     )
                 )
-                
+
             );
-        
-        
         return supplyTop - supplyNOM;
     }
 
@@ -228,80 +222,71 @@ contract BondingNOM is Ownable {
         return x >= 0 ? x : -x;
     }
 
-
     function buyNOM(uint256 estAmountNOM, uint256 allowSlip) public payable {
         require(msg.value > 0, "No ETH");
         uint256 amountNOM = buyQuoteETH(msg.value);
 
         // Positive slippage is bad.  Negative slippage is good.
         // Positive slippage means we will receive less NOM than estimated
-        int128 slippage = estAmountNOM - amountNOM;
+        int128 slippage = int128(estAmountNOM.sub(amountNOM));
 
         if (slippage > int128(0)) {
             // Check for slippage. Int128 used because slippage may be positive or negative
             require(
                 abs(slippage) < 
                     int128(
-                        SafeMath.mul(
-                            // Divide by 1000 because we multiplied the percentage
-                            // by 10^4 before sending
-                            SafeMath.div(estAmountNOM, 10000),
-                            allowSlip
-                        )   
+                        // Divide by 1000 because we multiplied the percentage
+                        // by 10^4 before sending
+                        estAmountNOM.div(10000).mul(allowSlip)
                     ),
                 "Slippage greater than allowed"
             );
         }
-           
-        // Update total supply released by Bonding Curve
-        supplyNOM = SafeMath.add(supplyNOM, amountNOM);
 
+        // Update total supply released by Bonding Curve
+        supplyNOM = supplyNOM.add(amountNOM);
         // Update current bond curve price
         priceBondCurve = priceAtSupply(supplyNOM);
 
-        emit Transaction(msg.sender, amountNOM, msg.value, priceBondCurve, supplyNOM, "buy", slippage);
-
         nc.transfer(msg.sender, amountNOM);
+
+        emit Transaction(msg.sender, amountNOM, msg.value, priceBondCurve, supplyNOM, "buy", slippage);
     }
 
-    // Returns Sell Quote: NOM for ETH (Dec 18)
-    // 1. Determine supply top: priceBondCurve - 1% = Top Sale Price
-    // 2. Integrate over curve to find ETH
-    // ETH = a/3((supplyNOM_Top/a)^3 - (supplyNOM_Bot/a)^3)
-    // 3. Subtract supply bottom from top to get #NOM for ETH
-    // Parameters:
-    // Input
-    // uint256 amountNOM: amount of NOM to be sold (18 decimal)
-    // Output
-    // uint256: amount of ETH paid in Wei or ETH (18 decimal)
+
+    /// @param amountNOM amount of NOM
+    /// @return Return Sell Quote: NOM for ETH (Dec 18)
+    /// @notice 1. Determine supply top: priceBondCurve - 1% = Top Sale Price
+    /// 2. Integrate over curve to find ETH: `ETH = a/3((supplyNOM_Top/a)^3 - (supplyNOM_Bot/a)^3)`
+    /// 3. Subtract supply bottom from top to get #NOM for ETH
     function sellQuoteNOM(uint256 amountNOM) public view returns(uint256) {
-        uint256 supplyBot = supplyNOM - amountNOM;
+        uint256 supplyBot = supplyNOM.sub(amountNOM);
         uint256 amountETH = NOMSupToETH(supplyNOM, supplyBot);
-        return SafeMath.sub(amountETH, SafeMath.div(amountETH, uint256(100)));
+        return amountETH.sub(amountETH.div(100));
     }
 
-    // allowSlip is a percentage represented as an percentage * 10^2 with a 2 decimal fixed point
-    // 1% would be uint256 representation of 0100, 1.25% would be 0125, 25.5% would be 2550
-    function sellNOM(uint256 amountNOM, uint256 estAmountETH, uint256 allowSlip) public {
+    /// @param amountNOM amount of NOM
+    /// @param estAmountETH estimation of ETH amount
+    /// @param allowSlip is a percentage represented as an percentage * 10^2 with a 2 decimal fixed point
+    /// 1% would be uint256 representation of 0100, 1.25% would be 0125, 25.5% would be 2550
+    /// @notice Transfer ETH worth amount of NOM to msg.sender
+    function sellNOM(uint256 amountNOM, uint256 estAmountETH, uint256 allowSlip) public payable {
         require(nc.allowance(msg.sender, address(this)) >= amountNOM, "sender has not enough allowance");
 
         uint256 amountETH = sellQuoteNOM(amountNOM);
-        
+
         // Positive slippage is bad.  Negative slippage is good.
         // Positive slippage means we will receive less ETH than estimated
-        int128 slippage = estAmountETH - amountETH;
+        int128 slippage = int128(estAmountETH.sub(amountETH));
 
         if (slippage > int128(0)) {
             // Check for slippage. Int128 used because slippage may be positive or negative
             require(
                 abs(slippage) < 
                     int128(
-                        SafeMath.mul(
-                            // Divide by 1000 because we multiplied the percentage
-                            // by 10^4 before sending
-                            SafeMath.div(estAmountNOM, 10000), 
-                            allowSlip
-                        )   
+                        // Divide by 1000 because we multiplied the percentage
+                        // by 10^4 before sending
+                        estAmountETH.div(10000).mul(allowSlip)
                     ),
                 "Slippage greater than allowed"
             );
@@ -309,46 +294,40 @@ contract BondingNOM is Ownable {
 
         // Transfer NOM to contract
         nc.transferFrom(msg.sender, address(this), amountNOM);
-        
         // Update persistent contract state variables
         // Update total supply released by Bonding Curve
-        supplyNOM = SafeMath.sub(supplyNOM, amountNOM);
+        supplyNOM = supplyNOM.sub(amountNOM);
         // Update current bond curve price
         priceBondCurve = priceAtSupply(supplyNOM);
-        
         emit Transaction(msg.sender, amountNOM, amountETH, priceBondCurve, supplyNOM, "sell", slippage);
 
         // Transfer ETH to Sender
         payable(msg.sender).transfer(amountETH);
     }
 
+    /// @return Teambalance in ETH
+    /// @notice 1. Calculate amount ETH to cover all current NOM outstanding based on bonding curve integration.
+    /// 2. Subtraction lockedETH from Contract Balance to get amount available for withdrawal.
     function teamBalance() public view returns(uint256) {
         if (supplyNOM == 0) {
             return address(this).balance;
         }
-        // Determine available ETH for payment
-        // 1. Calculate amount ETH to cover all current NOM outstanding
-        //    based on bonding curve integration.
-        uint256 burnedNOM = SafeMath.sub(a, nc.totalSupply());
+
+        uint256 burnedNOM = a.sub(nc.totalSupply());
         uint256 lockedETH = NOMSupToETH(supplyNOM, burnedNOM);
-        // 2. Subtraction lockedETH from Contract Balance to get amount 
-        //    available for withdrawal.
-        return SafeMath.sub(address(this).balance, lockedETH);
+        return address(this).balance.sub(lockedETH);
     }
 
+    /// @notice 1. Calculate amount ETH to cover all current NOM outstanding based on bonding curve integration.
+    /// 2. Subtraction lockedETH from Contract Balance to get amount available for withdrawal.
     function withdraw() public onlyOwner returns(bool success) {
         if (supplyNOM == 0) {
             payable(msg.sender).transfer(address(this).balance);
             return true;
         }
-        // Determine available ETH for payment
-        // 1. Calculate amount ETH to cover all current NOM outstanding
-        //    based on bonding curve integration.
-        uint256 burnedNOM = SafeMath.sub(a, nc.totalSupply());
+        uint256 burnedNOM = a.sub(nc.totalSupply());
         uint256 lockedETH = NOMSupToETH(supplyNOM, burnedNOM);
-        // 2. Subtraction lockedETH from Contract Balance to get amount 
-        //    available for withdrawal.
-        uint256 paymentETH = SafeMath.sub(address(this).balance, lockedETH);
+        uint256 paymentETH = address(this).balance.sub(lockedETH);
         // Transfer ETH to Owner
         payable(msg.sender).transfer(paymentETH);
         return true;


### PR DESCRIPTION
Implemented SafeMath library for uint256 so that we can reduce the code amount.
So we can convert the code to like this
`SafeMath.mul(a, Safemath.div(b, c) => a.mul(b.div(c))`