### PR TITLE
Add tradingEnabled flag for the BondingNOM.sol contract.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,8 @@ Hardhat is used to manage smart contract deployment and testing.
 - `yarn deploy:${network}` : Available networks `mainnet`, `rinkeyby`, `goerli`, `localhost`. For custom network it's configurable on `hardhat.config.js`  Deploy Script will automatically verify the contract
 - `yarn compile` : Compile the contracts from `/contracts`
 - `yarn run-node` : Running a node instance on the local network. We use this to obeserving the events and transactions.
+
+## Deployment
+- `yarn deploy:${network}` : Available networks `mainnet`, `rinkeyby`, `goerli`, `localhost`. For custom network it's configurable on `hardhat.config.js`  Deploy Script will automatically verify the contract
+- Open deployed contract in the chain explorer and call `enableTrading` method from the owner address to allow the 
+usage of `buyNOM` functions. !!! Attention that change is permanent, once the trading is enabled it will be enabled forever. !!!

--- a/contracts/BondingNOM.sol
+++ b/contracts/BondingNOM.sol
@@ -24,6 +24,7 @@ contract BondingNOM is Ownable {
     uint256 public priceBondCurve = 0;
     uint8 public decimals = 18;
     uint256 public a = SafeMath.mul(100000000, 10**decimals);
+    bool public tradingEnabled = false;
 
     event Transaction(address indexed _by, uint256 amountNOM, uint256 amountETH, uint256 price, uint256 supply, string buyOrSell, int256 slippage);
 
@@ -31,6 +32,11 @@ contract BondingNOM is Ownable {
         // Add in the NOM ERC20 contract address
         NOMTokenContract = NOMContAddr;
         nc = ERC20Token(NOMContAddr);
+    }
+
+    /// @return Return the bool value which indicates whether the trading is enabled.
+    function getTradingEnabled() public view returns (bool) {
+        return tradingEnabled;
     }
 
     /// @notice Return the NOM Token Contract address
@@ -243,6 +249,7 @@ contract BondingNOM is Ownable {
     /// @param estAmountNOM amount of NOM
     /// @param allowSlip amount of slippage allowed in 0100 means 1%
     function buyNOM(uint256 estAmountNOM, uint256 allowSlip) public payable {
+        require(tradingEnabled, "The trading is disabled");
         require(msg.value > 0, "Amount ETH sent with request equal to zero");
         require(estAmountNOM <= (a.sub(supplyNOM)), "Estimated amount of bNOM greater bonded supply of bNOM");
 
@@ -273,7 +280,6 @@ contract BondingNOM is Ownable {
 
         emit Transaction(msg.sender, amountNOM, msg.value, priceBondCurve, supplyNOM, "buy", slippage);
     }
-
 
     /// @param amountNOM amount of NOM
     /// @return Return Sell Quote: NOM for ETH (Dec 18)
@@ -354,6 +360,12 @@ contract BondingNOM is Ownable {
         payable(msg.sender).transfer(paymentETH);
         return true;
     }
+
+    /// @notice Enables trading.
+    function enableTrading() public onlyOwner {
+        tradingEnabled = true;
+    }
+
 }
 
 

--- a/test/bonding.js
+++ b/test/bonding.js
@@ -39,6 +39,14 @@ describe("Bonding Curve Tests", function () {
     console.log(`NOM Bonding Contract NOM Balance: ${balance}`)
     console.log('\n*************************************************************************\n')
 
+    // the trading is disabled by default
+    let tradingEnabled = await BondingNOM.getTradingEnabled()
+    assert.equal(false, tradingEnabled);
+    // enable trading
+    await BondingNOM.enableTrading()
+    tradingEnabled = await BondingNOM.getTradingEnabled()
+    assert.equal(true, tradingEnabled);
+
     contAddrs = {
       BNOMERC20: NOMtoken.address,
       BondingNOM: BondingNOM.address


### PR DESCRIPTION
Added the flag and functions to enable or disable the buyNOM functions in the BondingNOM.sol. 
This change allows the contract to be protected from the frontrunning transactions before the mainnet release. 
The only contract owner can control it.